### PR TITLE
Disabling Affinity Cookies

### DIFF
--- a/resources/resourceApp/azuredeploy.jsonc
+++ b/resources/resourceApp/azuredeploy.jsonc
@@ -111,7 +111,6 @@
       "properties": {
         "enabled": true,
         "serverFarmId": "[parameters('appserviceResourceId')]",
-        "clientAffinityEnabled": false,
         "siteConfig": {
           "linuxFxVersion": "[concat('DOCKER|', parameters('containerRegistryName'), '.azurecr.io/', toLower(parameters('webAppName')), ':', parameters('containerImageTag'))]",
           "appSettings": "[union(variables('globalAppSettings'), parameters('environmentVariables'), equinor.createSettingsObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference(resourceId('microsoft.insights/components/', variables('appInsightsName'))).InstrumentationKey), equinor.createSettingsObject('DOCKER_REGISTRY_SERVER_URL', reference(resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName')), '2019-05-01').loginServer), equinor.createSettingsObject('DOCKER_REGISTRY_SERVER_USERNAME', listCredentials(resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName')), '2019-05-01').username), equinor.createSettingsObject('DOCKER_REGISTRY_SERVER_PASSWORD', listCredentials(resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName')), '2019-05-01').passwords[0].value))]"
@@ -138,6 +137,7 @@
               ],
               "supportCredentials": false
             },
+            "clientAffinityEnabled": false,
             "http20Enabled": false,
             "minTlsVersion": "1.2",
             "ftpsState": "Disabled",

--- a/resources/resourceApp/azuredeploy.jsonc
+++ b/resources/resourceApp/azuredeploy.jsonc
@@ -111,6 +111,7 @@
       "properties": {
         "enabled": true,
         "serverFarmId": "[parameters('appserviceResourceId')]",
+        "clientAffinityEnabled": false,
         "siteConfig": {
           "linuxFxVersion": "[concat('DOCKER|', parameters('containerRegistryName'), '.azurecr.io/', toLower(parameters('webAppName')), ':', parameters('containerImageTag'))]",
           "appSettings": "[union(variables('globalAppSettings'), parameters('environmentVariables'), equinor.createSettingsObject('APPINSIGHTS_INSTRUMENTATIONKEY', reference(resourceId('microsoft.insights/components/', variables('appInsightsName'))).InstrumentationKey), equinor.createSettingsObject('DOCKER_REGISTRY_SERVER_URL', reference(resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName')), '2019-05-01').loginServer), equinor.createSettingsObject('DOCKER_REGISTRY_SERVER_USERNAME', listCredentials(resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName')), '2019-05-01').username), equinor.createSettingsObject('DOCKER_REGISTRY_SERVER_PASSWORD', listCredentials(resourceId('Microsoft.ContainerRegistry/registries/', parameters('containerRegistryName')), '2019-05-01').passwords[0].value))]"


### PR DESCRIPTION
When running behind a AGW, the affinity cookies is rejected as they have the wrong Domain configured. Disabling them as we don't, as far as I know, have any applications with state. 

Docs for the property: https://docs.microsoft.com/en-us/azure/templates/microsoft.web/2018-02-01/sites#siteproperties-object