### PR TITLE
Adding exclusion rule to appgw for oauth2 callback with token

### DIFF
--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -483,6 +483,13 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               "ruleSetType": "Microsoft_BotManagerRuleSet",
               "ruleSetVersion": "0.1"
             }
+          ],
+          "exclusions": [
+              {
+                  "matchVariable": "RequestArgNames",
+                  "selectorMatchOperator": "Equals",
+                  "selector": "code"
+              }
           ]
         }
       }

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -485,11 +485,11 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
             }
           ],
           "exclusions": [
-              {
-                  "matchVariable": "RequestArgNames",
-                  "selectorMatchOperator": "Equals",
-                  "selector": "code"
-              }
+            {
+              "matchVariable": "RequestArgNames",
+              "selectorMatchOperator": "Equals",
+              "selector": "code"
+            }
           ]
         }
       }


### PR DESCRIPTION
There is a AGW rule that triggers when oauth2 callback happens, which we need to exclude. As far as I could find, this is the only way of excluding checks. Ideally we would exclude on URL, but currently v2 seems to only support request arg names.

https://docs.microsoft.com/en-us/azure/templates/microsoft.network/2018-08-01/applicationgateways#applicationgatewayfirewallexclusion-object