### PR TITLE
Output resourceId of created data factory

### DIFF
--- a/resources/resourceDataFactory/azuredeploy.jsonc
+++ b/resources/resourceDataFactory/azuredeploy.jsonc
@@ -46,6 +46,10 @@
         "dataFactoryPrincipalId": {
             "type": "string",
             "value": "[reference(resourceId('Microsoft.DataFactory/factories', parameters('dataFactoryName')), '2018-06-01', 'full').identity.principalId]"
+        },
+        "dataFactoryResourceId" : {
+            "type": "string",
+            "value": "[resourceId('Microsoft.DataFactory/factories', parameters('dataFactoryName'))]"
         }
     }
 }


### PR DESCRIPTION
To ease the creation of Data Factory alerts on the outside of this template expose the resourceId of the created data factory. 