### PR TITLE
Setting forwarded host and protocol in request header

### DIFF
--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -279,9 +279,6 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               },
               "httpListener": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', variables('application-gateway-name'), 'http-listener')]"
-
-
-
               }
             }
           }

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -286,6 +286,33 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
             }
           }
         ],
+        "rewriteRuleSets": [
+          {
+            "name": "forward-host-header",
+            "properties": {
+              "rewriteRules": [
+                {
+                  "ruleSequence": 100,
+                  "conditions": [],
+                  "name": "forward-host-header",
+                  "actionSet": {
+                    "requestHeaderConfigurations": [
+                      {
+                        "headerName": "X-Forwarded-Host",
+                        "headerValue": "{var_host}"
+                      },
+                      {
+                        "headerName": "X-Forwarded-Proto",
+                        "headerValue": "{var_request_scheme}"
+                      }
+                    ],
+                    "responseHeaderConfigurations": []
+                  }
+                }
+              ]
+            }
+          }
+        ],
         "redirectConfigurations": [
           {
             "name": "http-to-https-redirect-config",
@@ -367,9 +394,9 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               },
               "defaultBackendHttpSettings": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('defaultApplication'), '-http-settings'))]"
-              //},
-              //"defaultRewriteRuleSet": {
-//                "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
+              },
+              "defaultRewriteRuleSet": {
+                "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
               },
               "copy": [
                 {
@@ -384,9 +411,9 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
                       },
                       "backendHttpSettings": {
                         "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('applications')[copyIndex('pathRules')].name, '-http-settings'))]"
-                      //},
-                   //   "rewriteRuleSet": {
-                     //   "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
+                      },
+                      "rewriteRuleSet": {
+                        "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
                       }
                     }
                   }

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -279,7 +279,37 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               },
               "httpListener": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/httpListeners', variables('application-gateway-name'), 'http-listener')]"
+
+
+
               }
+            }
+          }
+        ],
+        "rewriteRuleSets": [
+          {
+            "name": "forward-host-header",
+            "properties": {
+              "rewriteRules": [
+                {
+                  "ruleSequence": 100,
+                  "conditions": [],
+                  "name": "forward-host-header",
+                  "actionSet": {
+                    "requestHeaderConfigurations": [
+                      {
+                        "headerName": "X-Forwarded-Host",
+                        "headerValue": "{var_host}"
+                      },
+                      {
+                        "headerName": "X-Forwarded-Proto",
+                        "headerValue": "{var_request_scheme}"
+                      }
+                    ],
+                    "responseHeaderConfigurations": []
+                  }
+                }
+              ]
             }
           }
         ],
@@ -365,6 +395,10 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               "defaultBackendHttpSettings": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('defaultApplication'), '-http-settings'))]"
               },
+
+              "defaultRewriteRuleSet": {
+                "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
+              },
               "copy": [
                 {
                   "name": "pathRules",
@@ -378,6 +412,9 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
                       },
                       "backendHttpSettings": {
                         "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('applications')[copyIndex('pathRules')].name, '-http-settings'))]"
+                      },
+                      "rewriteRuleSet": {
+                        "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
                       }
                     }
                   }

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -291,7 +291,7 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               "rewriteRules": [
                 {
                   "ruleSequence": 100,
-                  "conditions": [],
+                  "conditions": "[json(' [ ] ')]",
                   "name": "forward-host-header-rule",
                   "actionSet": {
                     "requestHeaderConfigurations": [
@@ -304,7 +304,7 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
                         "headerValue": "{var_request_scheme}"
                       }
                     ],
-                    "responseHeaderConfigurations": []
+                    "responseHeaderConfigurations": "[json(' [ ] ')]"
                   }
                 }
               ]

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -286,33 +286,6 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
             }
           }
         ],
-        "rewriteRuleSets": [
-          {
-            "name": "forward-host-header",
-            "properties": {
-              "rewriteRules": [
-                {
-                  "ruleSequence": 100,
-                  "conditions": [],
-                  "name": "forward-host-header",
-                  "actionSet": {
-                    "requestHeaderConfigurations": [
-                      {
-                        "headerName": "X-Forwarded-Host",
-                        "headerValue": "{var_host}"
-                      },
-                      {
-                        "headerName": "X-Forwarded-Proto",
-                        "headerValue": "{var_request_scheme}"
-                      }
-                    ],
-                    "responseHeaderConfigurations": []
-                  }
-                }
-              ]
-            }
-          }
-        ],
         "redirectConfigurations": [
           {
             "name": "http-to-https-redirect-config",
@@ -394,9 +367,9 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               },
               "defaultBackendHttpSettings": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('defaultApplication'), '-http-settings'))]"
-              },
-              "defaultRewriteRuleSet": {
-                "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
+              //},
+              //"defaultRewriteRuleSet": {
+//                "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
               },
               "copy": [
                 {
@@ -411,9 +384,9 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
                       },
                       "backendHttpSettings": {
                         "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('applications')[copyIndex('pathRules')].name, '-http-settings'))]"
-                      },
-                      "rewriteRuleSet": {
-                        "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
+                      //},
+                   //   "rewriteRuleSet": {
+                     //   "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
                       }
                     }
                   }

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -289,12 +289,13 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
         "rewriteRuleSets": [
           {
             "name": "forward-host-header",
+            "type": "Microsoft.Network/applicationGateways/rewriteRuleSets",
             "properties": {
               "rewriteRules": [
                 {
                   "ruleSequence": 100,
                   "conditions": [],
-                  "name": "forward-host-header",
+                  "name": "forward-host-header-rule",
                   "actionSet": {
                     "requestHeaderConfigurations": [
                       {

--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -395,7 +395,6 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               "defaultBackendHttpSettings": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', variables('application-gateway-name'), concat(parameters('defaultApplication'), '-http-settings'))]"
               },
-
               "defaultRewriteRuleSet": {
                 "id": "[resourceId('Microsoft.Network/applicationGateways/rewriteRuleSets', variables('application-gateway-name'), 'forward-host-header')]"
               },


### PR DESCRIPTION
When forwarding it's sometimes nice to be able to detect the proxy host header (not only the app). Oauth2 proxy can use this info to dynamically create post login URL (tested with moe)