### PR TITLE
Expose the resourceId of created/updated Azure Sql database

### DIFF
--- a/resources/resourceAzureSqlDatabase/azuredeploy.jsonc
+++ b/resources/resourceAzureSqlDatabase/azuredeploy.jsonc
@@ -52,5 +52,11 @@
                 "collation": "[parameters('databaseCollation')]"
             }
         }
-    ]
+    ],
+    "outputs" : {
+        "azureSqlDatabaseResourceId" : {
+            "type" : "string",
+            "value": "[resourceId('Microsoft.Sql/servers/databases', parameters('sqlServerName') , parameters('databaseName'))]"
+        }
+    }
 }

--- a/scripts/VerifyTemplates.ps1
+++ b/scripts/VerifyTemplates.ps1
@@ -23,7 +23,7 @@ foreach ($file in $files) {
     Write-Host "Testing $fileName"
     Copy-Item -Path $fileName -Destination "azuredeploy.json"
 
-    if (("*resourceAzureSql*", "*resourceAzureSqlDatabase*", "*resourceServiceBus*" | %{$directory -like $_} ) -contains $true) {
+    if (("*resourceAzureSql*", "*resourceAzureSqlDatabase*", "*resourceServiceBus*", "*resourceAppInsights*" | %{$directory -like $_} ) -contains $true) {
         $r = Test-AzTemplate  -Skip "apiVersions_Should_Be_Recent"
     } else {
         $r = Test-AzTemplate


### PR DESCRIPTION
Need to expose the created Azure Sql database resourceId so that it can be used when e.g adding metric alarms.