### PR TITLE
Adjusted default http timeout

### DIFF
--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -545,7 +545,7 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
                 "protocol": "Https",
                 "cookieBasedAffinity": "Disabled",
                 "pickHostNameFromBackendAddress": true,
-                "requestTimeout": 20,
+                "requestTimeout": 300,
                 "probe": {
                   "id": "[resourceId('Microsoft.Network/applicationGateways/probes', variables('application-gateway-name'), concat(parameters('applications')[copyIndex('backendHttpSettingsCollection')].name, '-probe'))]"
                 }


### PR DESCRIPTION
For now, just setting a higher timeout for http requests through the application gateway. Later, this might be something we should look at setting on a per app basis