### PR TITLE
Added ignore in WAF for Oauth2 Proxy token in cookies

### DIFF
--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -625,6 +625,11 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               "matchVariable": "RequestArgNames",
               "selectorMatchOperator": "Equals",
               "selector": "code"
+            },
+            {
+              "matchVariable": "RequestCookieNames",
+              "selectorMatchOperator": "Equals",
+              "selector": "_oauth2_proxy"
             }
           ]
         }


### PR DESCRIPTION
Sometimes they contain dashes it seems, that triggers the FW to disallow some token. 