### PR TITLE
Enabled public network access for event grid

### DIFF
--- a/resources/resourceEventGrid/azuredeploy.jsonc
+++ b/resources/resourceEventGrid/azuredeploy.jsonc
@@ -48,7 +48,7 @@
             "tags": "[parameters('tags')]",
             "properties": {
                 "inputSchema": "EventGridSchema",
-                "publicNetworkAccess": "Disabled"
+                "publicNetworkAccess": "Enabled"
             }
         },
         {


### PR DESCRIPTION
Opening form public networks as we don't have the CoreAPI inside a vnet