### PR TITLE
Expose service bus queue requiresSession property

### DIFF
--- a/resources/resourceApp/azuredeploy.jsonc
+++ b/resources/resourceApp/azuredeploy.jsonc
@@ -88,7 +88,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2018-11-01",
+      "apiVersion": "2020-06-01",
       "name": "[parameters('webAppName')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -109,7 +109,7 @@
       "resources": [
         {
           "type": "config",
-          "apiVersion": "2018-11-01",
+          "apiVersion": "2020-06-01",
           "name": "web",
           "location": "[parameters('location')]",
           "dependsOn": [

--- a/resources/resourceAppWindows/azuredeploy.jsonc
+++ b/resources/resourceAppWindows/azuredeploy.jsonc
@@ -78,7 +78,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2018-11-01",
+      "apiVersion": "2020-06-01",
       "name": "[parameters('webAppName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
@@ -129,7 +129,7 @@
     {
       "condition": "[equals(parameters('language'),'python')]",
       "type": "Microsoft.Web/sites/siteextensions",
-      "apiVersion": "2018-11-01",
+      "apiVersion": "2020-06-01",
       "name": "[concat(parameters('webAppName'), '/azureappservice-python364x64')]",
       "location": "[parameters('location')]",
       "dependsOn": [

--- a/resources/resourceFunctionAppWindows/azuredeploy.jsonc
+++ b/resources/resourceFunctionAppWindows/azuredeploy.jsonc
@@ -11,12 +11,12 @@
     "appServicePlanSku": {
       "type": "string",
       "allowedValues": [
-        "S1",   // Standard 
-        "S2",   // Standard 
-        "S3",   // Standard 
-        "P1V2", // Premium V2 
-        "P2V2", // Premium V2 
-        "P3V2", // Premium V2       
+        "S1",   // Standard
+        "S2",   // Standard
+        "S3",   // Standard
+        "P1V2", // Premium V2
+        "P2V2", // Premium V2
+        "P3V2", // Premium V2
         "Y1" // Dynamic consumption plan
       ],
       "defaultValue": "Y1"

--- a/resources/resourceServiceBus/azuredeploy.jsonc
+++ b/resources/resourceServiceBus/azuredeploy.jsonc
@@ -8,6 +8,10 @@
     "serviceBusQueueName": {
       "type": "string"
     },
+    "serviceBusQueueRequiresSession": {
+      "type": "bool",
+      "defaultValue": false
+    },
     "serviceBusSku": {
       "type": "string",
       "allowedValues": [
@@ -51,7 +55,7 @@
             "lockDuration": "PT5M",
             "maxSizeInMegabytes": 5120,
             "requiresDuplicateDetection": false,
-            "requiresSession": false,
+            "requiresSession": "[parameters('serviceBusQueueRequiresSession')]",
             "defaultMessageTimeToLive": "P14D",
             "deadLetteringOnMessageExpiration": false,
             "duplicateDetectionHistoryTimeWindow": "PT10M",


### PR DESCRIPTION
In order to support Service Bus -> Azure Function FIFO (first in first out) concept we need to enable sessions  on the service bus queue we are creating. 

Should a broader discussion on how to expose more of the properties like maxSizeInMegabytes, defaultMessageTimeToLive etc.