### PR TITLE
Handle user YAML missing roles

### DIFF
--- a/scripts/sqlUserManagement/SqlUserManagement.psm1
+++ b/scripts/sqlUserManagement/SqlUserManagement.psm1
@@ -188,7 +188,9 @@ function Publish-DatabaseUsersAndPermissions {
             }
 
             $userConfig.roles | ForEach-Object {
-                $sqlStatement += $sqlStatementFormat -f (Get-AzureSqlAddRoleMemberStatement $currentUserName $_)
+                if ($_){
+                    $sqlStatement += $sqlStatementFormat -f (Get-AzureSqlAddRoleMemberStatement $currentUserName $_)
+                }
             }
         }
     }


### PR DESCRIPTION
When user is not added to a role, the ForEach-Object
still executes. Therefore we must only generate a
sql statment when the value exists.