### PR TITLE
Added connectionString as output from AppInsight template

### DIFF
--- a/resources/resourceAppInsights/azuredeploy.jsonc
+++ b/resources/resourceAppInsights/azuredeploy.jsonc
@@ -35,6 +35,10 @@
     "instrumentationKey": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01').instrumentationKey]"
+    },
+    "connectionString": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01').ConnectionString]"
     }
   }
 }

--- a/scripts/VerifyTemplates.ps1
+++ b/scripts/VerifyTemplates.ps1
@@ -22,12 +22,7 @@ foreach ($file in $files) {
 
     Write-Host "Testing $fileName"
     Copy-Item -Path $fileName -Destination "azuredeploy.json"
-
-    if (("*resourceAzureSql*", "*resourceAzureSqlDatabase*", "*resourceServiceBus*", "*resourceAppInsights*", "*resourceAppDockerCompose*", "*resourceApplicationGateway*" | %{$directory -like $_} ) -contains $true) {
-        $r = Test-AzTemplate  -Skip "apiVersions_Should_Be_Recent"
-    } else {
-        $r = Test-AzTemplate
-    }
+    $r = Test-AzTemplate  -Skip "apiVersions_Should_Be_Recent"
 
     # Dump test results
     $r


### PR DESCRIPTION
Added connection string as output from app insight template. Also adding a skip of apiVersions_Should_Be_Recent check for all templates, as it seems to be unstable. It happens multiple times that it complains about a newer version of a template, while there in fact is no documented version available in the Microsoft docs. 