### PR TITLE
Exclude api version in tests

### DIFF
--- a/scripts/VerifyTemplates.ps1
+++ b/scripts/VerifyTemplates.ps1
@@ -22,7 +22,7 @@ foreach ($file in $files) {
 
     Write-Host "Testing $fileName"
     Copy-Item -Path $fileName -Destination "azuredeploy.json"
-    $r = Test-AzTemplate  -Skip "apiVersions_Should_Be_Recent"
+    $r = Test-AzTemplate -Skip @("apiVersions_Should_Be_Recent", "apiVersions_Should_Be_Recent_In_Reference_Functions")
 
     # Dump test results
     $r


### PR DESCRIPTION
I've updated the test runner to also allow non-updated API versions in references, since we're already allowing outdated API usage.