### PR TITLE
Ignore oauth2 cookie in WAF

### DIFF
--- a/resources/resourceApplicationGateway/azuredeploy.jsonc
+++ b/resources/resourceApplicationGateway/azuredeploy.jsonc
@@ -667,6 +667,11 @@ https://github.com/equinor/ioc-shared-infrastructure/blob/master/LICENSE
               "matchVariable": "RequestCookieNames",
               "selectorMatchOperator": "Equals",
               "selector": "_oauth2_proxy"
+            },
+            {
+              "matchVariable": "RequestCookieNames",
+              "selectorMatchOperator": "Equals",
+              "selector": "_oauth2_proxy_csrf"
             }
           ]
         }


### PR DESCRIPTION
We were already ignoring _oauth2_proxy, but in some cases
Chrome was setting cookie _oauth2_proxy_csrf, this too was
intercepted by the firewall and an exemption for this one
is needed too.