### PR TITLE
Bump removed api version and remove ImmediatePurgeDataOn30Days

### DIFF
--- a/resources/resourceFunctionAppWindows/azuredeploy.jsonc
+++ b/resources/resourceFunctionAppWindows/azuredeploy.jsonc
@@ -99,7 +99,7 @@
   "resources": [
     {
       "type": "microsoft.insights/components",
-      "apiVersion": "2020-02-02-preview",
+      "apiVersion": "2020-02-02",
       "name": "[variables('appinsightsName')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -108,7 +108,6 @@
         "Application_Type": "web",
         "Request_Source": "rest",
         "RetentionInDays": 90,
-        "ImmediatePurgeDataOn30Days": true,
         "IngestionMode": "[parameters('ingestionMode')]",
         "publicNetworkAccessForIngestion": "Enabled",
         "publicNetworkAccessForQuery": "Enabled",


### PR DESCRIPTION
Bump removed API version to non-retired version and remove ImmediatePurgeDataOn30Days as it was not possible to use it with new API version.

Reasons for removal:
![image](https://github.com/equinor/ioc-shared-infrastructure/assets/25591240/92f6ff8a-6c43-4029-94ca-5f7d4257ab66)
![image](https://github.com/equinor/ioc-shared-infrastructure/assets/25591240/3570ee57-c53d-481c-a670-19666b538d84)