### PR TITLE
Bump removed api version and remove ImmediatePurgeDataOn30Days 2

### DIFF
--- a/resources/resourceFunctionApp/azuredeploy.jsonc
+++ b/resources/resourceFunctionApp/azuredeploy.jsonc
@@ -127,7 +127,7 @@
   "resources": [
     {
       "type": "microsoft.insights/components",
-      "apiVersion": "2020-02-02-preview",
+      "apiVersion": "2020-02-02",
       "name": "[variables('appinsightsName')]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -136,7 +136,6 @@
         "Application_Type": "web",
         "Request_Source": "rest",
         "RetentionInDays": 90,
-        "ImmediatePurgeDataOn30Days": true,
         "IngestionMode": "[parameters('ingestionMode')]",
         "publicNetworkAccessForIngestion": "Enabled",
         "publicNetworkAccessForQuery": "Enabled",


### PR DESCRIPTION
Previously fixed for function app for windows, and now being fixed for function app,