### PR TITLE
add bicep build steps with debug

### DIFF
--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -36,21 +36,21 @@ jobs:
         continue-on-error: true
         uses: Azure/bicep-build-action@v1.0.1
         with: 
-          bicepFilePath: ./resources/resourceApp/webApp.json
+          bicepFilePath: ./resources/resourceApp/webApp.bicep
           outputFilePath: ./resources/resourceApp/webApp-temp.json
 
       - name: Build bicep - app config
         continue-on-error: true
         uses: Azure/bicep-build-action@v1.0.1
         with: 
-          bicepFilePath: ./resources/resourceAppConfiguration/appConfiguration.json
+          bicepFilePath: ./resources/resourceAppConfiguration/appConfiguration.bicep
           outputFilePath: ./resources/resourceAppConfiguration/appConfiguration-temp.json
 
       - name: Build bicep - container registry
         continue-on-error: true
         uses: Azure/bicep-build-action@v1.0.1
         with: 
-          bicepFilePath: ./resources/resourceContainerRegistry/containerregistry.json
+          bicepFilePath: ./resources/resourceContainerRegistry/containerregistry.bicep
           outputFilePath: ./resources/resourceContainerRegistry/containerregistry-temp.json
 
       - name: Build bicep - key vault
@@ -64,7 +64,7 @@ jobs:
         continue-on-error: true
         uses: Azure/bicep-build-action@v1.0.1
         with: 
-          bicepFilePath: ./resources/resourceKeyVaultAccess/keyvaultAccessPolicies.json
+          bicepFilePath: ./resources/resourceKeyVaultAccess/keyvaultAccessPolicies.bicep
           outputFilePath: ./resources/resourceKeyVaultAccess/keyvaultAccessPolicies-temp.json
 
       - name: Run Snyk to check configuration files for security issues

--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -30,7 +30,23 @@ jobs:
       #actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Temporary step - display files in resourceKeyVault directory 1
+        run: |
+          ls ./resources/resourceKeyVault
+
+      - name: Build bicep - key vault
+        continue-on-error: true
+        uses: Azure/bicep-build-action@v1.0.1
+        with: 
+          bicepFilePath: ./resources/resourceKeyVault/keyvault.bicep
+          outputFilePath: ./resources/resourceKeyVault/keyvault-temp.json
+
+      - name: Temporary step - display files in resourceKeyVault directory 2
+        run: |
+          ls ./resources/resourceKeyVault
+
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.
         # In this case we want to upload the issues to GitHub Code Scanning

--- a/.github/workflows/snyk-infrastructure.yml
+++ b/.github/workflows/snyk-infrastructure.yml
@@ -32,9 +32,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Temporary step - display files in resourceKeyVault directory 1
-        run: |
-          ls ./resources/resourceKeyVault
+      - name: Build bicep - web app
+        continue-on-error: true
+        uses: Azure/bicep-build-action@v1.0.1
+        with: 
+          bicepFilePath: ./resources/resourceApp/webApp.json
+          outputFilePath: ./resources/resourceApp/webApp-temp.json
+
+      - name: Build bicep - app config
+        continue-on-error: true
+        uses: Azure/bicep-build-action@v1.0.1
+        with: 
+          bicepFilePath: ./resources/resourceAppConfiguration/appConfiguration.json
+          outputFilePath: ./resources/resourceAppConfiguration/appConfiguration-temp.json
+
+      - name: Build bicep - container registry
+        continue-on-error: true
+        uses: Azure/bicep-build-action@v1.0.1
+        with: 
+          bicepFilePath: ./resources/resourceContainerRegistry/containerregistry.json
+          outputFilePath: ./resources/resourceContainerRegistry/containerregistry-temp.json
 
       - name: Build bicep - key vault
         continue-on-error: true
@@ -43,9 +60,12 @@ jobs:
           bicepFilePath: ./resources/resourceKeyVault/keyvault.bicep
           outputFilePath: ./resources/resourceKeyVault/keyvault-temp.json
 
-      - name: Temporary step - display files in resourceKeyVault directory 2
-        run: |
-          ls ./resources/resourceKeyVault
+      - name: Build bicep - key vault
+        continue-on-error: true
+        uses: Azure/bicep-build-action@v1.0.1
+        with: 
+          bicepFilePath: ./resources/resourceKeyVaultAccess/keyvaultAccessPolicies.json
+          outputFilePath: ./resources/resourceKeyVaultAccess/keyvaultAccessPolicies-temp.json
 
       - name: Run Snyk to check configuration files for security issues
         # Snyk can be used to break the build when it detects security issues.


### PR DESCRIPTION
This Snyk IAC action builds temporary ARM template files from the Bicep files, then runs the IAC test on the whole repository.

Known issues:
- webApp.json (built from webApp.bicep) ends up not being parsable by the Snyk CLI, even though the other four files are built and parsed without error. This affects but is not in scope of this ticket. Created an issue in the repo as a reminder.
- It isn't possible to delete the issues produced by the IAC Test anymore, and Snyk is only displaying the creation time without the last update time. Thus after manually adding them all via the CLI, I was unable to confirm with certainty that the tests are being pushed from this Github Action to the Web UI. I can only confirm that the action's log shows the same number of high and medium severity issues as the Web UI and the localhost CLI.
-  The current structure requires manually adding new files every time. I'd like to delay the extra refinement until I can verify the previous item.