### PR TITLE
[IE-8066] - Add useful database scripts

### DIFF
--- a/scripts/databaseUtilityScripts/Check currently running queries.sql
+++ b/scripts/databaseUtilityScripts/Check currently running queries.sql
@@ -1,0 +1,23 @@
+SELECT
+    qt.text AS [SQL Query],
+    s.login_name AS [User],
+    r.start_time AS [Start Time],
+	CURRENT_TIMESTAMP AS [Time now],
+    r.status,
+	r.wait_type,
+	r.wait_resource,
+    r.percent_complete AS [Progress],
+    r.blocking_session_id AS [Blocking Session],
+    r.wait_time AS [Wait Time (ms)],
+	r.dop AS [Degree of Parallelism]
+FROM 
+    sys.dm_exec_requests r
+JOIN
+    sys.dm_exec_sessions s ON r.session_id = s.session_id
+CROSS APPLY 
+    sys.dm_exec_sql_text(r.sql_handle) AS qt
+WHERE 
+    r.sql_handle IS NOT NULL
+    AND r.session_id <> @@SPID -- Exclude this current query
+ORDER BY 
+    r.start_time;

--- a/scripts/databaseUtilityScripts/Check index fragmentation and pagefill.sql
+++ b/scripts/databaseUtilityScripts/Check index fragmentation and pagefill.sql
@@ -1,0 +1,24 @@
+SELECT 
+	  OBJECT_SCHEMA_NAME(ips.object_id) AS schema_name
+    , OBJECT_NAME(ips.object_id) AS object_name
+    , i.name AS index_name
+    , i.type_desc AS index_type
+    , ips.avg_fragmentation_in_percent
+    , ips.avg_page_space_used_in_percent
+    , ips.page_count
+    , ips.alloc_unit_type_desc
+FROM sys.dm_db_index_physical_stats(DB_ID(), default, default, default, 'SAMPLED') AS ips
+INNER JOIN sys.indexes AS i
+ON ips.object_id = i.object_id
+   AND ips.index_id = i.index_id
+WHERE
+	1=1
+	AND OBJECT_SCHEMA_NAME(ips.object_id)	= '<schema_name>' -- Insert schema name
+	AND OBJECT_NAME(ips.object_id)			= '<table_name>'  -- Insert table name
+	AND i.name								= '<index_name>'  -- Insert index name
+	-- Note: Comment out any of the above filters to not filter on the given property
+ORDER BY 
+	  OBJECT_SCHEMA_NAME(ips.object_id)
+	, OBJECT_NAME(ips.object_id)
+	, i.name
+	, ips.avg_fragmentation_in_percent;

--- a/scripts/databaseUtilityScripts/Check index usage script.sql
+++ b/scripts/databaseUtilityScripts/Check index usage script.sql
@@ -1,0 +1,25 @@
+SELECT
+    dbs.name AS database_name,
+    objs.name AS object_name,
+    idxs.name AS index_name,
+    idx_stats.user_seeks,
+    idx_stats.user_scans,
+    idx_stats.user_lookups,
+    idx_stats.user_updates,
+    idx_stats.last_user_seek,
+    idx_stats.last_user_scan,
+    idx_stats.last_user_lookup,
+    idx_stats.last_user_update
+FROM 
+    sys.dm_db_index_usage_stats idx_stats
+INNER JOIN 
+    sys.indexes idxs ON idx_stats.object_id = idxs.object_id AND idx_stats.index_id = idxs.index_id
+INNER JOIN 
+    sys.objects objs ON idxs.object_id = objs.object_id
+INNER JOIN 
+    sys.databases dbs ON idx_stats.database_id = dbs.database_id
+WHERE 
+    dbs.name = '' -- Insert database name (Required)
+    AND idx_stats.database_id = DB_ID(''); -- Insert database name (Required)
+    AND objs.name = '' -- Insert table name or comment out for all tables
+    AND idxs.name = '' -- Insert index name or comment out for all indexes

--- a/scripts/databaseUtilityScripts/Check partition status.sql
+++ b/scripts/databaseUtilityScripts/Check partition status.sql
@@ -1,0 +1,50 @@
+WITH partition_boundaries AS (
+    SELECT
+        pf.function_id,
+        pf.boundary_value_ON_right,
+        pf.name as [partition_function],
+        ps.name as partition_schema,
+        prv.boundary_id as [partition_number],
+        prv.[value] as [partition_value] ,
+        ds.data_space_id
+    FROM sys.partition_functions pf
+    LEFT JOIN sys.partition_range_values prv
+        ON prv.function_id = pf.function_id
+    INNER JOIN sys.partition_schemes ps
+        ON  ps.function_id = pf.function_id
+    INNER JOIN sys.data_spaces ds
+        ON ds.data_space_id = ps.data_space_id
+)
+SELECT
+    CONCAT(s.name, '.', o.name) as object_name,
+    i.name as index_name,
+    p.partition_number,
+    pb.partition_schema,
+    pb.partition_function,
+    pb.partition_value,
+    p.[rows] as row_in_partition,
+    p_stat.row_count as p_stat_row_in_partition
+FROM sys.partitions p
+INNER JOIN sys.dm_db_partition_stats p_stat
+    ON p_stat.partition_id = p.partition_id
+    AND p_stat.partition_number = p.partition_number
+INNER JOIN sys.objects o
+    ON o.object_id = p_stat.object_id
+INNER JOIN sys.schemas s
+    ON s.schema_id = o.schema_id
+INNER JOIN sys.indexes i
+    ON i.object_id = p_stat.object_id
+    AND i.index_id = p_stat.index_id
+LEFT JOIN partition_boundaries pb
+    ON pb.data_space_id = i.data_space_id
+    AND pb.partition_number + IIF(pb.boundary_value_ON_right = 1, 1,0 ) = p.partition_number
+WHERE
+    s.name = 'dbo'
+AND o.name NOT IN(
+    '__RefactorLog'
+)
+ORDER BY
+    s.name,
+    o.name,
+    i.name,
+    p.partition_number

--- a/scripts/databaseUtilityScripts/Check permissions and roles.sql
+++ b/scripts/databaseUtilityScripts/Check permissions and roles.sql
@@ -1,0 +1,60 @@
+-- Permissions
+WITH db_permissions (Grantee, Securable, Permission, Schemas, Objects, Columns) 
+AS (
+SELECT
+      USER_NAME(dbPer.grantee_principal_id)   AS Grantee
+    , dbPer.class_desc                        AS Securable
+    , dbPer.permission_name                   AS Permission
+    , sch.name                                AS Schemas
+    , obj.name                                AS Objects
+    , col.name                                AS Columns
+FROM sys.database_permissions AS dbPer
+JOIN sys.database_principals AS dbPri
+	ON dbPer.grantee_principal_id = dbPri.principal_id
+LEFT JOIN sys.schemas AS sch
+	ON dbPer.major_id = sch.schema_id
+LEFT JOIN sys.objects AS obj 
+    ON dbPer.major_id = obj.object_id AND dbPer.class_desc <> 'SCHEMA'
+LEFT JOIN sys.columns AS col 
+    ON dbPer.major_id = col.object_id AND dbPer.minor_id = col.column_id AND dbPer.class_desc = 'OBJECT_OR_COLUMN'
+WHERE 
+    1=1
+    AND USER_NAME(dbPer.grantee_principal_id) <> 'Public'
+)
+SELECT
+      Grantee
+    , Securable
+    , Permission
+    , Schemas
+    , Objects
+    , Columns
+FROM
+    db_permissions
+WHERE
+  1=1
+  -- AND Grantee LIKE '' -- Database user's name, e.g. Admin
+  -- AND Securable LIKE '' -- DATABASE | SCHEMA | OBJECT_OR_COLUMN etc., see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-permissions-transact-sql?view=sql-server-ver15
+  -- AND Permission LIKE '' -- SELECT | ALTER | UPDATE | CONNECT | DELETE etc., see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-permissions-transact-sql?view=sql-server-ver15#database-permissions
+  -- AND Schemas LIKE '' -- 'dbo' or other custom schema name
+  -- AND Objects LIKE '' -- Table name
+  -- AND Columns LIKE '' -- Column name
+  -- Comment in any of the above lines to filter the results
+ORDER BY
+    Grantee
+    , Securable
+    , Permission
+    , Schemas
+    , Objects
+    , Columns;
+
+-- Roles
+SELECT 
+	  DP1.name AS DatabaseRoleName
+	, isnull (DP2.name, 'No members') AS DatabaseUserName
+ FROM sys.database_role_members AS DRM
+ RIGHT OUTER JOIN sys.database_principals AS DP1
+   ON DRM.role_principal_id = DP1.principal_id
+ LEFT OUTER JOIN sys.database_principals AS DP2
+   ON DRM.member_principal_id = DP2.principal_id
+WHERE DP1.type = 'R'
+ORDER BY DP1.name;

--- a/scripts/databaseUtilityScripts/Count rows of all tables in a db.sql
+++ b/scripts/databaseUtilityScripts/Count rows of all tables in a db.sql
@@ -1,0 +1,20 @@
+SELECT 
+    t.NAME AS TableName,
+    s.Name AS SchemaName,
+    p.rows AS RowCounts
+FROM 
+    sys.tables t
+INNER JOIN      
+    sys.indexes i ON t.OBJECT_ID = i.object_id
+INNER JOIN 
+    sys.partitions p ON i.object_id = p.OBJECT_ID AND i.index_id = p.index_id
+INNER JOIN
+    sys.schemas s ON t.schema_id = s.schema_id
+WHERE 
+    t.NAME NOT LIKE 'dt%' AND
+    i.OBJECT_ID > 255 AND   
+    i.index_id <= 1
+GROUP BY 
+    t.NAME, s.Name, p.Rows
+ORDER BY 
+    p.rows DESC

--- a/scripts/databaseUtilityScripts/Search for schema, table or column.sql
+++ b/scripts/databaseUtilityScripts/Search for schema, table or column.sql
@@ -1,0 +1,17 @@
+SELECT
+	  s.name AS schema_name
+	, t.name AS table_name
+	, c.name AS column_name
+FROM sys.schemas s
+INNER JOIN sys.tables t ON s.schema_id = t.schema_id
+INNER JOIN sys.columns c ON t.object_id = c.object_id
+WHERE
+	1=1
+	AND s.name LIKE '%schema_name%'  -- Replace "schema_name" with the schema you're looking for
+	AND t.name LIKE '%table_name%'  -- Replace "table_name" with the table you're looking for
+	AND c.name LIKE '%column_name%' -- Replace "column_name" with the name of the column you're looking for
+	-- Note: Comment out any of the above to not filter on that property
+ORDER BY 
+	  schema_name
+	, table_name
+	, column_name

--- a/scripts/databaseUtilityScripts/Simple execution timer.sql
+++ b/scripts/databaseUtilityScripts/Simple execution timer.sql
@@ -1,0 +1,14 @@
+-- Timer
+DECLARE @IntervalTime DATETIME = SYSDATETIME()
+
+-- Insert your code to be timed here --
+
+PRINT(CONCAT('Duration: ', DATEDIFF(MILLISECOND, @IntervalTime, SYSDATETIME()), ' milliseconds.'))
+
+
+-- For subsequeny timers in the same run, use the following syntax
+SET @IntervalTime = SYSDATETIME()
+
+-- Insert your code to be timed here --
+
+PRINT(CONCAT('Duration: ', DATEDIFF(MILLISECOND, @IntervalTime, SYSDATETIME()), ' milliseconds.'))

--- a/scripts/databaseUtilityScripts/readme.md
+++ b/scripts/databaseUtilityScripts/readme.md
@@ -1,0 +1,9 @@
+# Database utility scripts
+
+## Purpose
+
+The purpose of this folder is to gather various database utility scripts for Azure SQL database.
+
+## Background
+
+Many of the scripts in mssql are complex and non-intuitive, and simple things like checking permissions and roles can require lots googling, testing and adjustments to achieve a decent script. Instead of inventing the wheel several times, I propose these scripts can be added to ioc-shared-infrastructure for safekeeping for current and future employees. This will also allow developers to collaborate on further refining the scripts.


### PR DESCRIPTION
Many of the scripts in mssql are complex and non-intuitive, and simple things like checking permissions and roles can require lots googling, testing and adjustments to achieve a decent script. Instead of inventing the wheel several times, I propose these scripts can be added to ioc-shared-infrastructure for safekeeping for current and future employees. This will also allow developers to collaborate on further refining the scripts.