### PR TITLE
[IP-7006] - Update Whitelisting Of Equinor Ips

### DIFF
--- a/BICEP_RESOURCE_VERSIONS.md
+++ b/BICEP_RESOURCE_VERSIONS.md
@@ -7,7 +7,7 @@
 | resourceAppConfiguration/azuredeploy.bicep                             | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceAppInsights/azuredeploy.bicep                                  | 1.0 | 2024-05-15 12:34:41 +0200 | cad6e60 |
 | resourceAppServicePlan/azuredeploy.bicep                               | 1.1 | 2025-04-01 13:33:20 +0200 | 5630ea6 |
-| resourceApplicationGateway/azuredeploy.bicep                           | appgateway:1.2 | 2025-08-13 16:28:26 +0200 | 1dbcb66 |
+| resourceApplicationGateway/azuredeploy.bicep                           | appgateway:1.2 | 2025-08-14 13:26:14 +0200 | 745fb54 |
 | resourceContainerApp/azuredeploy.bicep                                 | 1.0 | 2025-01-24 11:52:48 +0100 | 045f97e |
 | resourceContainerRegistry/azuredeploy.bicep                            | 1.0 | 2025-01-24 11:52:48 +0100 | 045f97e |
 | resourceContainerRegistryTask/azuredeploy.bicep                        | 1.0 | 2024-08-04 14:15:47 +0200 | d5b0c44 |
@@ -21,11 +21,11 @@
 | resourcePostgresql/azuredeploy.bicep                                   | 1.0 | 2024-06-12 15:23:29 +0200 | 91d7307 |
 | resourcePostgresqlDatabases/azuredeploy.bicep                          | 1.0 | 2024-06-12 15:29:18 +0200 | d59079f |
 | resourcePostgresqlFlexibleDatabases/azuredeploy.bicep                  | 1.0 | 2024-11-28 10:29:22 +0100 | f53527c |
-| resourcePostgresqlFlexibleServer/azuredeploy.bicep                     | postgresflexibleserver:1.3 | 2025-05-05 13:18:52 +0200 | aa1c6c7 |
+| resourcePostgresqlFlexibleServer/azuredeploy.bicep                     | postgresflexibleserver:1.4 | 2026-02-03 15:32:20 +0100 | 83021fe |
 | resourcePrivateDnsZone/azuredeploy.bicep                               | privatednszone:1.0 | 2025-05-30 16:13:02 +0200 | 345b7e6 |
 | resourcePrivateDnsZoneRecord/azuredeploy.bicep                         | dnszonerecord:1.0 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
 | resourcePrivateEndpoints/azuredeploy.bicep                             | privateendpoints:1.0 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
 | resourcePublicIp/azuredeploy.bicep                                     | publicip:1.2 | 2025-06-23 14:05:09 +0200 | dd40af5 |
 | resourceRedis/azuredeploy.bicep                                        | redis:1.4 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
 | resourceStorageAccounts/azuredeploy.bicep                              | storageaccount:1.1 | 2025-06-12 16:13:54 +0200 | 7919f8f |
-| resourceVnet/azuredeploy.bicep                                         | vnet:2.1 | 2025-08-13 16:28:26 +0200 | 1dbcb66 |
+| resourceVnet/azuredeploy.bicep                                         | vnet:2.1 | 2025-08-14 13:26:14 +0200 | 745fb54 |

--- a/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
+++ b/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
@@ -1,4 +1,4 @@
-// Version 1.3 Module postgresflexibleserver
+// Version 1.4 Module postgresflexibleserver
 param administratorLogin string
 
 @secure()
@@ -148,19 +148,19 @@ resource postgresServerName_AllowAllWindowsAzureIps 'Microsoft.DBforPostgreSQL/f
 
 resource postgresServerName_Equinor_Bergen 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   parent: postgresServer
-  name: 'Equinor-Bergen'
+  name: 'Equinor-internal-networks'
   properties: {
-    startIpAddress: '143.97.2.35'
-    endIpAddress: '143.97.2.35'
+    startIpAddress: '136.164.1.0'
+    endIpAddress: '136.164.1.255'
   }
 }
 
 resource postgresServerName_Equinor_Statoil_Approved 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   parent: postgresServer
-  name: 'Equinor-Statoil-Approved'
+  name: 'Equinor-approved-networks'
   properties: {
-    startIpAddress: '143.97.2.129'
-    endIpAddress: '143.97.2.129'
+    startIpAddress: '143.97.110.0'
+    endIpAddress: '143.97.110.255'
   }
 }
 


### PR DESCRIPTION
Updating the hardcoded IP whitelistings in the postgres SQL server to align with new IP ranges as posted on Slack:

“To improve resiliency and scalability we plan to change the current public source ip of 143.97.2.35 for Equinor internal networks in Norway. The new public source will be a full subnet, 136.164.1.0/24.

To improve resiliency and scalability we plan to change the current public source ip of 143.97.110.1 for equinor-internet and equinor-approved networks. The new public source will be a full subnet, 143.97.110.0/24.”

I used the following commands to publish the update of the module:

make publish.dev BICEP_FILE=resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep MODULE_NAME=postgresflexibleserver VERSION=1.4