### PR TITLE
[IP-7037] - Parameterize enableRbacAuthorization for key vault

### DIFF
--- a/BICEP_RESOURCE_VERSIONS.md
+++ b/BICEP_RESOURCE_VERSIONS.md
@@ -13,7 +13,7 @@
 | resourceContainerRegistryTask/azuredeploy.bicep                        | 1.0 | 2024-08-04 14:15:47 +0200 | d5b0c44 |
 | resourceEventHub/azuredeploy.bicep                                     | eventhub:1.1 | 2025-08-08 15:51:13 +0200 | 5fc184c |
 | resourceFunctionApp/azuredeploy.bicep                                  | 1.0 | 2025-04-04 08:48:55 +0200 | 3a25754 |
-| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.1 | 2026-02-09 13:32:53 +0100 | 8b4529e |
+| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.2 | 2026-02-09 13:32:53 +0100 | 8b4529e |
 | resourceKeyVaultAccess/azuredeploy.bicep                               | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceKeyVaultSecrets/azuredeploy.bicep                              | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceLogAnalyticsWorkspace/azuredeploy.bicep                        | 1.0 | 2024-05-22 10:36:13 +0200 | f06dca9 |

--- a/BICEP_RESOURCE_VERSIONS.md
+++ b/BICEP_RESOURCE_VERSIONS.md
@@ -13,7 +13,7 @@
 | resourceContainerRegistryTask/azuredeploy.bicep                        | 1.0 | 2024-08-04 14:15:47 +0200 | d5b0c44 |
 | resourceEventHub/azuredeploy.bicep                                     | eventhub:1.1 | 2025-08-08 15:51:13 +0200 | 5fc184c |
 | resourceFunctionApp/azuredeploy.bicep                                  | 1.0 | 2025-04-04 08:48:55 +0200 | 3a25754 |
-| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.2 | 2026-02-09 13:32:53 +0100 | 8b4529e |
+| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.2 | 2026-02-09 13:47:09 +0100 | bf41def |
 | resourceKeyVaultAccess/azuredeploy.bicep                               | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceKeyVaultSecrets/azuredeploy.bicep                              | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceLogAnalyticsWorkspace/azuredeploy.bicep                        | 1.0 | 2024-05-22 10:36:13 +0200 | f06dca9 |

--- a/BICEP_RESOURCE_VERSIONS.md
+++ b/BICEP_RESOURCE_VERSIONS.md
@@ -13,7 +13,7 @@
 | resourceContainerRegistryTask/azuredeploy.bicep                        | 1.0 | 2024-08-04 14:15:47 +0200 | d5b0c44 |
 | resourceEventHub/azuredeploy.bicep                                     | eventhub:1.1 | 2025-08-08 15:51:13 +0200 | 5fc184c |
 | resourceFunctionApp/azuredeploy.bicep                                  | 1.0 | 2025-04-04 08:48:55 +0200 | 3a25754 |
-| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.1 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
+| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.1 | 2026-02-09 13:32:53 +0100 | 8b4529e |
 | resourceKeyVaultAccess/azuredeploy.bicep                               | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceKeyVaultSecrets/azuredeploy.bicep                              | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceLogAnalyticsWorkspace/azuredeploy.bicep                        | 1.0 | 2024-05-22 10:36:13 +0200 | f06dca9 |

--- a/resources/resourceKeyVault/azuredeploy.bicep
+++ b/resources/resourceKeyVault/azuredeploy.bicep
@@ -1,4 +1,4 @@
-// Version 1.1 Module keyvault
+// Version 1.2 Module keyvault
 param tenantId string
 param keyvaultName string
 param accessPolicies array = []

--- a/resources/resourceKeyVault/azuredeploy.bicep
+++ b/resources/resourceKeyVault/azuredeploy.bicep
@@ -22,10 +22,11 @@ param vnetName string = ''
 param subnetName string = ''
 @description('The private DNS zone ID for the Key Vault private endpoint. This is optional and can be used to link the private endpoint to a private DNS zone.')
 param privateDnsZoneId string = ''
+param enableRbacAuthorization bool = false
 
 var rgScope = resourceGroup()
 
-resource keyvaultResource 'Microsoft.KeyVault/vaults@2023-07-01' = {
+resource keyvaultResource 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: keyvaultName
   location: rgScope.location
   tags: tags
@@ -36,7 +37,7 @@ resource keyvaultResource 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enabledForDiskEncryption: true
     enabledForTemplateDeployment: true
     enablePurgeProtection: true
-    enableRbacAuthorization: false
+    enableRbacAuthorization: enableRbacAuthorization
     enableSoftDelete: true
     networkAcls: networkAcls
     provisioningState: 'Succeeded'


### PR DESCRIPTION
It is currently not possible to set this value to true, which is the value recommended by microsoft (https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-access-policy). By parameterizing it and setting the default value to false, upgrading does not force any changes, but allows for a manual override to true.

Ran the following command to publish new bicep module version:
`make publish.dev BICEP_FILE=resources/resourceKeyVault/azuredeploy.bicep MODULE_NAME=keyvault VERSION=1.2`