### PR TITLE
IP-7094 - Add "server properties" to postgresql module and facilitate for RBAC on webapps

### DIFF
--- a/BICEP_RESOURCE_VERSIONS.md
+++ b/BICEP_RESOURCE_VERSIONS.md
@@ -3,7 +3,7 @@
 # Bicep Versions
 | Resource | Version | Changed | Commit |
 |----------|----------|----------|----------|
-| resourceApp/azuredeploy.bicep                                          | webapp:1.5 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
+| resourceApp/azuredeploy.bicep                                          | webapp:1.6 | 2026-03-04 18:23:24 +0100 | a507694 |
 | resourceAppConfiguration/azuredeploy.bicep                             | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceAppInsights/azuredeploy.bicep                                  | 1.0 | 2024-05-15 12:34:41 +0200 | cad6e60 |
 | resourceAppServicePlan/azuredeploy.bicep                               | 1.1 | 2025-04-01 13:33:20 +0200 | 5630ea6 |
@@ -13,7 +13,7 @@
 | resourceContainerRegistryTask/azuredeploy.bicep                        | 1.0 | 2024-08-04 14:15:47 +0200 | d5b0c44 |
 | resourceEventHub/azuredeploy.bicep                                     | eventhub:1.1 | 2025-08-08 15:51:13 +0200 | 5fc184c |
 | resourceFunctionApp/azuredeploy.bicep                                  | 1.0 | 2025-04-04 08:48:55 +0200 | 3a25754 |
-| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.2 | 2026-02-09 13:47:09 +0100 | bf41def |
+| resourceKeyVault/azuredeploy.bicep                                     | keyvault:1.2 | 2026-02-10 08:03:15 +0100 | bab924b |
 | resourceKeyVaultAccess/azuredeploy.bicep                               | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceKeyVaultSecrets/azuredeploy.bicep                              | 1.0 | 2024-05-15 10:52:23 +0200 | 9e5211b |
 | resourceLogAnalyticsWorkspace/azuredeploy.bicep                        | 1.0 | 2024-05-22 10:36:13 +0200 | f06dca9 |
@@ -21,7 +21,7 @@
 | resourcePostgresql/azuredeploy.bicep                                   | 1.0 | 2024-06-12 15:23:29 +0200 | 91d7307 |
 | resourcePostgresqlDatabases/azuredeploy.bicep                          | 1.0 | 2024-06-12 15:29:18 +0200 | d59079f |
 | resourcePostgresqlFlexibleDatabases/azuredeploy.bicep                  | 1.0 | 2024-11-28 10:29:22 +0100 | f53527c |
-| resourcePostgresqlFlexibleServer/azuredeploy.bicep                     | postgresflexibleserver:1.4 | 2026-02-04 09:15:46 +0100 | 171ec33 |
+| resourcePostgresqlFlexibleServer/azuredeploy.bicep                     | postgresflexibleserver:1.5 | 2026-03-04 18:23:24 +0100 | a507694 |
 | resourcePrivateDnsZone/azuredeploy.bicep                               | privatednszone:1.0 | 2025-05-30 16:13:02 +0200 | 345b7e6 |
 | resourcePrivateDnsZoneRecord/azuredeploy.bicep                         | dnszonerecord:1.0 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
 | resourcePrivateEndpoints/azuredeploy.bicep                             | privateendpoints:1.0 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |

--- a/BICEP_RESOURCE_VERSIONS.md
+++ b/BICEP_RESOURCE_VERSIONS.md
@@ -21,7 +21,7 @@
 | resourcePostgresql/azuredeploy.bicep                                   | 1.0 | 2024-06-12 15:23:29 +0200 | 91d7307 |
 | resourcePostgresqlDatabases/azuredeploy.bicep                          | 1.0 | 2024-06-12 15:29:18 +0200 | d59079f |
 | resourcePostgresqlFlexibleDatabases/azuredeploy.bicep                  | 1.0 | 2024-11-28 10:29:22 +0100 | f53527c |
-| resourcePostgresqlFlexibleServer/azuredeploy.bicep                     | postgresflexibleserver:1.5 | 2026-03-04 18:23:24 +0100 | a507694 |
+| resourcePostgresqlFlexibleServer/azuredeploy.bicep                     | postgresflexibleserver:1.5 | 2026-04-08 10:49:11 +0200 | e5fea93 |
 | resourcePrivateDnsZone/azuredeploy.bicep                               | privatednszone:1.0 | 2025-05-30 16:13:02 +0200 | 345b7e6 |
 | resourcePrivateDnsZoneRecord/azuredeploy.bicep                         | dnszonerecord:1.0 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |
 | resourcePrivateEndpoints/azuredeploy.bicep                             | privateendpoints:1.0 | 2025-06-02 09:01:28 +0200 | 0c8caa6 |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Merging to this repo requires approval from 
 # the infrastructure team in IOC
-*       @Maryonsin @inghel @siback @MarcusNilsson
+*       @Maryonsin @inghel @MarcusNilsson

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Merging to this repo requires approval from 
 # the infrastructure team in IOC
-*       @Maryonsin @inghel @olemh @siback @franktore
+*       @Maryonsin @inghel @siback @MarcusNilsson

--- a/resources/resourceApp/azuredeploy.bicep
+++ b/resources/resourceApp/azuredeploy.bicep
@@ -1,4 +1,4 @@
-// Version 1.5 Module webapp
+// Version 1.6 Module webapp
 param webAppName string
 param location string = resourceGroup().location
 param tags object
@@ -39,6 +39,8 @@ param privatelinkVnetName string = ''
 param privatelinkSubnetName string = ''
 @description('The private DNS zone ID')
 param privateDnsZoneId string
+@description('Use managed identity to access Azure Container Registry images.')
+param acrUseManagedIdentityCreds bool = false
 
 var webapp_dns_name = '.azurewebsites.net'
 
@@ -46,6 +48,21 @@ func createSettingsObject (key string, value string) array => [
   {
     name: key
     value: value
+  }
+]
+
+var adminCredentials = acrUseManagedIdentityCreds ? [] : [
+  {
+    name: 'DOCKER_REGISTRY_SERVER_URL'
+    value: reference(resourceId(acrResourceGroup, 'Microsoft.ContainerRegistry/registries/', containerRegistryName), '2025-11-01').loginServer
+  }
+  {
+    name: 'DOCKER_REGISTRY_SERVER_USERNAME'
+    value: listCredentials(resourceId(acrResourceGroup, 'Microsoft.ContainerRegistry/registries/', containerRegistryName), '2025-11-01').username
+  }
+  {
+    name: 'DOCKER_REGISTRY_SERVER_PASSWORD'
+    value: listCredentials(resourceId(acrResourceGroup, 'Microsoft.ContainerRegistry/registries/', containerRegistryName), '2025-11-01').passwords[0].value
   }
 ]
 
@@ -72,7 +89,7 @@ var vnetNameProperty = (ouboundVnetName != '') ? {
   vnetName: ouboundVnetName
 } : {}
 
-resource webApp 'Microsoft.Web/sites@2023-12-01' = {
+resource webApp 'Microsoft.Web/sites@2024-04-01' = {
   name: webAppName
   location: location
   tags: tags
@@ -85,15 +102,16 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
     clientAffinityEnabled: false
     siteConfig: {
       linuxFxVersion: 'DOCKER|${containerRegistryName}.azurecr.io/${toLower(containerImageName)}:${containerImageTag}'
-      appSettings: union(globalAppSettings, environmentVariables, createSettingsObject('DOCKER_REGISTRY_SERVER_URL', reference(resourceId(acrResourceGroup, 'Microsoft.ContainerRegistry/registries/', containerRegistryName), '2023-07-01').loginServer), createSettingsObject('DOCKER_REGISTRY_SERVER_USERNAME', listCredentials(resourceId(acrResourceGroup, 'Microsoft.ContainerRegistry/registries/', containerRegistryName), '2023-07-01').username), createSettingsObject('DOCKER_REGISTRY_SERVER_PASSWORD', listCredentials(resourceId(acrResourceGroup, 'Microsoft.ContainerRegistry/registries/', containerRegistryName), '2023-07-01').passwords[0].value))
+      appSettings: union(globalAppSettings, environmentVariables, adminCredentials)
       appCommandLine: appCommandLine
+      acrUseManagedIdentityCreds: acrUseManagedIdentityCreds
     }
     httpsOnly: true
     ...virtualNetworkProperties
   }
 }
 
-resource webAppName_web 'Microsoft.Web/sites/config@2023-12-01' = {
+resource webAppName_web 'Microsoft.Web/sites/config@2025-03-01' = {
   parent: webApp
   name: 'web'
   properties: {
@@ -131,7 +149,7 @@ resource webAppBinding 'Microsoft.Web/sites/hostNameBindings@2024-04-01' = {
   }
 }
 
-resource vnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2023-12-01' = if (!empty(ouboundVnetName)) {
+resource vnetConnection 'Microsoft.Web/sites/virtualNetworkConnections@2025-03-01' = if (!empty(ouboundVnetName)) {
   parent: webApp
   name: outboundVnetConnectionName
   properties: {

--- a/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
+++ b/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
@@ -1,8 +1,8 @@
 // Version 1.4 Module postgresflexibleserver
-param administratorLogin string
+param administratorLogin string = ''
 
 @secure()
-param administratorLoginPassword string
+param administratorLoginPassword string = ''
 param tenantId string = '3aa4a235-b6e2-48d5-9195-7fcf05b459b0'
 param authPasswdConfig string = 'Enabled'
 param activeDirectoryAuthConfig string = 'Enabled'
@@ -70,6 +70,14 @@ param customMaintenanceWindowDayOfWeek int = 6
 param customMaintenanceWindowStartHour int = 0
 param customMaintenanceWindowStartMinute int = 30
 
+@description('Enable or disable Azure AD group sync for the PostgreSQL server.')
+@allowed([
+  ''
+  'on'
+  'off'
+])
+param enableGroupSync string = ''
+
 @description('''Server with Private Endpoint. This module creates a private endpoint for the server if privateEndpointName is defined.
 NB! For existing servers a private endpoint might not be eligible for creation.''')
 param privateEndpointName string = ''
@@ -87,8 +95,8 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' =
   sku: sku
   properties: {
     version: postgresVersion
-    administratorLogin: administratorLogin
-    administratorLoginPassword: administratorLoginPassword
+    administratorLogin: !empty(administratorLogin) ? administratorLogin : null
+    administratorLoginPassword: !empty(administratorLoginPassword) ? administratorLoginPassword : null
     authConfig: {
       activeDirectoryAuth: activeDirectoryAuthConfig
       passwordAuth: authPasswdConfig
@@ -161,6 +169,15 @@ resource postgresServerName_Equinor_Statoil_Approved 'Microsoft.DBforPostgreSQL/
   properties: {
     startIpAddress: '143.97.110.0'
     endIpAddress: '143.97.110.255'
+  }
+}
+
+resource pgAadAuthEnableGroupSync 'Microsoft.DBforPostgreSQL/flexibleServers/configurations@2024-08-01' = if(!empty(enableGroupSync)) {
+  parent: postgresServer
+  name: 'pgaadauth.enable_group_sync'
+  properties: {
+    value: enableGroupSync
+    source: 'user-override'
   }
 }
 

--- a/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
+++ b/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
@@ -99,7 +99,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' =
     administratorLoginPassword: !empty(administratorLoginPassword) ? administratorLoginPassword : null
     authConfig: {
       activeDirectoryAuth: activeDirectoryAuthConfig
-      passwordAuth: authPasswdConfig
+      passwordAuth: (!empty(administratorLogin) && !empty(administratorLoginPassword)) ? authPasswdConfig : 'Disabled'
       tenantId: tenantId
     }
     network: {

--- a/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
+++ b/resources/resourcePostgresqlFlexibleServer/azuredeploy.bicep
@@ -1,4 +1,4 @@
-// Version 1.4 Module postgresflexibleserver
+// Version 1.5 Module postgresflexibleserver
 param administratorLogin string = ''
 
 @secure()


### PR DESCRIPTION
Changes:
- acrUseManagedIdentityCreds added to web app to facilitate for RBAC permission model. Environment variables for non-RBAC permission model extracted out and made optional.
- Postgresql server password made optional. Also added enableGroupSync param to allow log in with personal az-accounts from entra admin group, so that the entra admin group display name does not have to be used as username during DB login